### PR TITLE
no need "w" argument

### DIFF
--- a/examples/appengine/hello/hello.go
+++ b/examples/appengine/hello/hello.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 func rootHandler(w traffic.ResponseWriter, r *traffic.Request) {
-  w.Render(w, "index", struct{
+  w.Render("index", struct{
     Message string
   }{
     "Hello Google App Engine",


### PR DESCRIPTION
Show this message `cannot use w (type traffic.ResponseWriter) as type string in function argument
` when I run the appengine example. I fix it. PR , pls.
