### PR TITLE
Replace ServeFile with ServeContent to use previously opened file

### DIFF
--- a/static_middleware.go
+++ b/static_middleware.go
@@ -2,7 +2,6 @@ package traffic
 
 import (
 	"net/http"
-	"path/filepath"
 )
 
 type StaticMiddleware struct {
@@ -28,8 +27,7 @@ func (middleware *StaticMiddleware) ServeHTTP(w ResponseWriter, r *Request, next
 
 	if info, err := file.Stat(); err == nil && !info.IsDir() {
 		w.Header().Del("Content-Type")
-		fullPath := filepath.Join(middleware.publicPath, path)
-		http.ServeFile(w, r.Request, fullPath)
+		http.ServeContent(w, r.Request, path, info.ModTime(), file)
 		return
 	}
 


### PR DESCRIPTION
The previous security fix was just about right but didn't work for one small corner case, that is if you have a file in the public directory with the same name as a file anywhere else on the system, someone can request the file in another location and retrieve it. 

To fix this I replace ServeFile with ServeContent, this also will not open the file twice to serve it.
